### PR TITLE
Using `bundles` for events and systems instead of `entities`

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,11 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [0.2.0] - 2024-02-28
+### Changed
+    Changed entities-based events and systems to bundle-based
+
+
 ## [0.1.9] - 2024-02-28
 ### Added
     Added function to call for CreateOrModify action

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_family"
-version = "0.1.9"
+version = "0.2.0"
 description = "A simple crate that helps with creating, updating, and removing parent-child components in Bevy"
 license = "Apache-2.0"
 edition = "2021"

--- a/examples/biological_clock.rs
+++ b/examples/biological_clock.rs
@@ -42,7 +42,10 @@ fn main() {
         .run();
 }
 
-fn interaction_panel(mut commands: Commands, mut contexts: EguiContexts, mut parent_event_writer: EventWriter<ParentEvent<Building, String>>) {
+fn interaction_panel(
+    mut contexts: EguiContexts,
+    mut parent_event_writer: EventWriter<ParentEvent<Building, String>>,
+) {
     let ctx = contexts.ctx_mut();
 
     egui::SidePanel::left("left_panel")
@@ -51,8 +54,7 @@ fn interaction_panel(mut commands: Commands, mut contexts: EguiContexts, mut par
             ui.label("Interaction");
             ui.horizontal(|ui| {
                 if ui.button("Add parent").clicked() {
-                    let building_id = commands.spawn(Building(std::time::Duration::from_secs(5))).id();
-                    parent_event_writer.send(ParentEvent::create("Building".into(), building_id));
+                    parent_event_writer.send(ParentEvent::create("Building".into(), Building(std::time::Duration::from_secs(5))));
                 }
             });
             ui.allocate_rect(ui.available_rect_before_wrap(), egui::Sense::hover());

--- a/examples/grandchildren.rs
+++ b/examples/grandchildren.rs
@@ -37,8 +37,8 @@ fn main() {
         .add_event::<ChildEvent<Level, String>>()
         .add_event::<ChildEvent<Room, String>>()
         .add_systems(Update, cud_parent_component::<Building, String>)
-        .add_systems(Update, cud_child_component::<Building, Level, String>)
-        .add_systems(Update, cud_child_component::<Level, Room, String>)
+        .add_systems(Update, cud_child_component::<Building, Level, Level, String>)
+        .add_systems(Update, cud_child_component::<Level, Room, Room, String>)
         .add_plugins(EguiPlugin)
         .add_systems(Update, interaction_panel)
         .add_systems(Update, lineage_panel)
@@ -46,7 +46,6 @@ fn main() {
 }
 
 fn interaction_panel(
-    mut commands: Commands,
     mut contexts: EguiContexts,
     mut building_event_writer: EventWriter<ParentEvent<Building, String>>,
     mut level_event_writer: EventWriter<ChildEvent<Level, String>>,
@@ -60,16 +59,13 @@ fn interaction_panel(
             ui.label("Building Interaction");
             ui.horizontal(|ui| {
                 if ui.button("Add building").clicked() {
-                    let building_id = commands.spawn(Building).id();
-                    building_event_writer.send(ParentEvent::create("Building".into(), building_id));
+                    building_event_writer.send(ParentEvent::create("Building".into(), Building));
                 }
                 if ui.button("Modify building").clicked() {
-                    let building_id = commands.spawn(Building).id();
-                    building_event_writer.send(ParentEvent::update("Building".into(), building_id));
+                    building_event_writer.send(ParentEvent::update("Building".into(), Building));
                 }
                 if ui.button("Remove building").clicked() {
-                    let building_id = commands.spawn(Building).id();
-                    building_event_writer.send(ParentEvent::delete("Building".into(), building_id));
+                    building_event_writer.send(ParentEvent::delete("Building".into(), Building));
                 }
             });
 
@@ -78,16 +74,25 @@ fn interaction_panel(
             ui.label("Level Interaction");
             ui.horizontal(|ui| {
                 if ui.button("Add level").clicked() {
-                    let level_id = commands.spawn(Level).id();
-                    level_event_writer.send(ChildEvent::create("Building".into(), "Level".into(), level_id));
+                    level_event_writer.send(ChildEvent::create(
+                        "Building".into(),
+                        "Level".into(),
+                        Level,
+                    ));
                 }
                 if ui.button("Modify level").clicked() {
-                    let level_id = commands.spawn(Level).id();
-                    level_event_writer.send(ChildEvent::update("Building".into(), "Level".into(), level_id));
+                    level_event_writer.send(ChildEvent::update(
+                        "Building".into(),
+                        "Level".into(),
+                        Level,
+                    ));
                 }
                 if ui.button("Remove level").clicked() {
-                    let level_id = commands.spawn(Level).id();
-                    level_event_writer.send(ChildEvent::delete("Building".into(), "Level".into(), level_id));
+                    level_event_writer.send(ChildEvent::delete(
+                        "Building".into(),
+                        "Level".into(),
+                        Level,
+                    ));
                 }
             });
 
@@ -96,16 +101,25 @@ fn interaction_panel(
             ui.label("Room Interaction");
             ui.horizontal(|ui| {
                 if ui.button("Add room").clicked() {
-                    let room_id = commands.spawn(Room).id();
-                    room_event_writer.send(ChildEvent::create("Level".into(), "Room".into(), room_id));
+                    room_event_writer.send(ChildEvent::create(
+                        "Level".into(),
+                        "Room".into(),
+                        Room,
+                    ));
                 }
                 if ui.button("Modify room").clicked() {
-                    let room_id = commands.spawn(Room).id();
-                    room_event_writer.send(ChildEvent::update("Level".into(), "Room".into(), room_id));
+                    room_event_writer.send(ChildEvent::update(
+                        "Level".into(),
+                        "Room".into(),
+                        Room,
+                    ));
                 }
                 if ui.button("Remove room").clicked() {
-                    let room_id = commands.spawn(Room).id();
-                    room_event_writer.send(ChildEvent::delete("Level".into(), "Room".into(), room_id));
+                    room_event_writer.send(ChildEvent::delete(
+                        "Level".into(),
+                        "Room".into(),
+                        Room,
+                    ));
                 }
             });
 

--- a/examples/parent_child.rs
+++ b/examples/parent_child.rs
@@ -33,7 +33,7 @@ fn main() {
         .add_event::<ParentEvent<Building, String>>()
         .add_event::<ChildEvent<Level, String>>()
         .add_systems(Update, cud_parent_component::<Building, String>)
-        .add_systems(Update, cud_child_component::<Building, Level, String>)
+        .add_systems(Update, cud_child_component::<Building, Level, Level, String>)
         .add_plugins(EguiPlugin)
         .add_systems(Update, interaction_panel)
         .add_systems(Update, lineage_panel)
@@ -41,7 +41,6 @@ fn main() {
 }
 
 fn interaction_panel(
-    mut commands: Commands,
     mut contexts: EguiContexts,
     mut parent_event_writer: EventWriter<ParentEvent<Building, String>>,
     mut child_event_writer: EventWriter<ChildEvent<Level, String>>,
@@ -54,16 +53,13 @@ fn interaction_panel(
             ui.label("Parent Interaction");
             ui.horizontal(|ui| {
                 if ui.button("Add parent").clicked() {
-                    let building_id = commands.spawn(Building).id();
-                    parent_event_writer.send(ParentEvent::create("Building".into(), building_id));
+                    parent_event_writer.send(ParentEvent::create("Building".into(), Building));
                 }
                 if ui.button("Modify parent").clicked() {
-                    let building_id = commands.spawn(Building).id();
-                    parent_event_writer.send(ParentEvent::update("Building".into(), building_id));
+                    parent_event_writer.send(ParentEvent::update("Building".into(), Building));
                 }
                 if ui.button("Remove parent").clicked() {
-                    let building_id = commands.spawn(Building).id();
-                    parent_event_writer.send(ParentEvent::delete("Building".into(), building_id));
+                    parent_event_writer.send(ParentEvent::delete("Building".into(), Building));
                 }
             });
 
@@ -72,20 +68,32 @@ fn interaction_panel(
             ui.label("Child Interaction");
             ui.horizontal(|ui| {
                 if ui.button("Add child").clicked() {
-                    let level_id = commands.spawn(Level).id();
-                    child_event_writer.send(ChildEvent::create("Building".into(), "Level".into(), level_id));
+                    child_event_writer.send(ChildEvent::create(
+                        "Building".into(),
+                        "Level".into(),
+                        Level,
+                    ));
                 }
                 if ui.button("Create or modify child").clicked() {
-                    let level_id = commands.spawn(Level).id();
-                    child_event_writer.send(ChildEvent::create_or_modify("Building".into(), "Level".into(), level_id));
+                    child_event_writer.send(ChildEvent::create_or_modify(
+                        "Building".into(),
+                        "Level".into(),
+                        Level,
+                    ));
                 }
                 if ui.button("Modify child").clicked() {
-                    let level_id = commands.spawn(Level).id();
-                    child_event_writer.send(ChildEvent::update("Building".into(), "Level".into(), level_id));
+                    child_event_writer.send(ChildEvent::update(
+                        "Building".into(),
+                        "Level".into(),
+                        Level,
+                    ));
                 }
                 if ui.button("Remove child").clicked() {
-                    let level_id = commands.spawn(Level).id();
-                    child_event_writer.send(ChildEvent::delete("Building".into(), "Level".into(), level_id));
+                    child_event_writer.send(ChildEvent::delete(
+                        "Building".into(),
+                        "Level".into(),
+                        Level,
+                    ));
                 }
             });
 

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -35,7 +35,10 @@ fn main() {
         .run();
 }
 
-fn interaction_panel(mut commands: Commands, mut contexts: EguiContexts, mut parent_event_writer: EventWriter<ParentEvent<Building, String>>) {
+fn interaction_panel(
+    mut contexts: EguiContexts,
+    mut parent_event_writer: EventWriter<ParentEvent<Building, String>>,
+) {
     let ctx = contexts.ctx_mut();
 
     egui::SidePanel::left("left_panel")
@@ -44,16 +47,13 @@ fn interaction_panel(mut commands: Commands, mut contexts: EguiContexts, mut par
             ui.label("Interaction");
             ui.horizontal(|ui| {
                 if ui.button("Add parent").clicked() {
-                    let building_id = commands.spawn(Building).id();
-                    parent_event_writer.send(ParentEvent::create("Building".into(), building_id));
+                    parent_event_writer.send(ParentEvent::create("Building".into(), Building));
                 }
                 if ui.button("Modify parent").clicked() {
-                    let building_id = commands.spawn(Building).id();
-                    parent_event_writer.send(ParentEvent::update("Building".into(), building_id));
+                    parent_event_writer.send(ParentEvent::update("Building".into(), Building));
                 }
                 if ui.button("Remove parent").clicked() {
-                    let building_id = commands.spawn(Building).id();
-                    parent_event_writer.send(ParentEvent::delete("Building".into(), building_id));
+                    parent_event_writer.send(ParentEvent::delete("Building".into(), Building));
                 }
             });
 

--- a/examples/two_parents.rs
+++ b/examples/two_parents.rs
@@ -41,7 +41,6 @@ fn main() {
 }
 
 fn interaction_panel(
-    mut commands: Commands,
     mut contexts: EguiContexts,
     mut parent_1_event_writer: EventWriter<ParentEvent<Parent1, String>>,
     mut parent_2_event_writer: EventWriter<ParentEvent<Parent2, String>>,
@@ -54,16 +53,16 @@ fn interaction_panel(
             ui.label("Parent 1");
             ui.horizontal(|ui| {
                 if ui.button("Add parent").clicked() {
-                    let parent_1 = commands.spawn(Parent1).id();
-                    parent_1_event_writer.send(ParentEvent::create("Parent1_name".into(), parent_1));
+                    parent_1_event_writer
+                        .send(ParentEvent::create("Parent1_name".into(), Parent1));
                 }
                 if ui.button("Modify parent").clicked() {
-                    let parent_1 = commands.spawn(Parent1).id();
-                    parent_1_event_writer.send(ParentEvent::update("Parent1_name".into(), parent_1));
+                    parent_1_event_writer
+                        .send(ParentEvent::update("Parent1_name".into(), Parent1));
                 }
                 if ui.button("Remove parent").clicked() {
-                    let parent_1 = commands.spawn(Parent1).id();
-                    parent_1_event_writer.send(ParentEvent::delete("Parent1_name".into(), parent_1));
+                    parent_1_event_writer
+                        .send(ParentEvent::delete("Parent1_name".into(), Parent1));
                 }
             });
 
@@ -72,16 +71,16 @@ fn interaction_panel(
             ui.label("Parent 2");
             ui.horizontal(|ui| {
                 if ui.button("Add parent").clicked() {
-                    let parent_2 = commands.spawn(Parent2).id();
-                    parent_2_event_writer.send(ParentEvent::create("Parent2_name".into(), parent_2));
+                    parent_2_event_writer
+                        .send(ParentEvent::create("Parent2_name".into(), Parent2));
                 }
                 if ui.button("Modify parent").clicked() {
-                    let parent_2 = commands.spawn(Parent2).id();
-                    parent_2_event_writer.send(ParentEvent::update("Parent2_name".into(), parent_2));
+                    parent_2_event_writer
+                        .send(ParentEvent::update("Parent2_name".into(), Parent2));
                 }
                 if ui.button("Remove parent").clicked() {
-                    let parent_2 = commands.spawn(Parent2).id();
-                    parent_2_event_writer.send(ParentEvent::delete("Parent2_name".into(), parent_2));
+                    parent_2_event_writer
+                        .send(ParentEvent::delete("Parent2_name".into(), Parent2));
                 }
             });
 

--- a/examples/uuid_identifier.rs
+++ b/examples/uuid_identifier.rs
@@ -50,7 +50,11 @@ impl Default for UuidResource {
     }
 }
 
-fn interaction_panel(mut commands: Commands, mut contexts: EguiContexts, mut parent_event_writer: EventWriter<ParentEvent<Building, Uuid>>, mut uuid_resource: Local<UuidResource>) {
+fn interaction_panel(
+    mut contexts: EguiContexts,
+    mut parent_event_writer: EventWriter<ParentEvent<Building, Uuid>>,
+    mut uuid_resource: Local<UuidResource>,
+) {
     let ctx = contexts.ctx_mut();
 
     egui::SidePanel::left("left_panel")
@@ -78,16 +82,16 @@ fn interaction_panel(mut commands: Commands, mut contexts: EguiContexts, mut par
             ui.label("Interaction");
             ui.horizontal(|ui| {
                 if ui.button("Add parent").clicked() {
-                    let building_entity = commands.spawn(Building).id();
-                    parent_event_writer.send(ParentEvent::create(uuid_resource.uuid, building_entity));
+                    parent_event_writer
+                        .send(ParentEvent::create(uuid_resource.uuid, Building));
                 }
                 if ui.button("Modify parent").clicked() {
-                    let building_entity = commands.spawn(Building).id();
-                    parent_event_writer.send(ParentEvent::update(uuid_resource.uuid, building_entity));
+                    parent_event_writer
+                        .send(ParentEvent::update(uuid_resource.uuid, Building));
                 }
                 if ui.button("Remove parent").clicked() {
-                    let building_entity = commands.spawn(Building).id();
-                    parent_event_writer.send(ParentEvent::delete(uuid_resource.uuid, building_entity));
+                    parent_event_writer
+                        .send(ParentEvent::delete(uuid_resource.uuid, Building));
                 }
             });
 

--- a/src/functions/mod.rs
+++ b/src/functions/mod.rs
@@ -19,7 +19,10 @@
 use super::*;
 
 /// Get the entity by the identifier.
-pub fn get_entity_by_identifier<T, U>(queries: &Query<(Entity, &Identifier<U>), (With<T>, With<Identifier<U>>)>, identifier: &Identifier<U>) -> Option<Entity>
+pub fn get_entity_by_identifier<T, U>(
+    queries: &Query<(Entity, &Identifier<U>), (With<T>, With<Identifier<U>>)>,
+    identifier: &Identifier<U>,
+) -> Option<Entity>
 where
     T: Component,
     U: PartialEq + Send + Sync + 'static,

--- a/src/structs/mod.rs
+++ b/src/structs/mod.rs
@@ -30,16 +30,16 @@ pub struct BiologicalClock {
 
 /// Event that is used to create, update and delete parent entities
 #[derive(Event)]
-pub struct ParentEvent<U, T> {
+pub struct ParentEvent<U: Bundle, T> {
     action: Action,
     self_identifier: Identifier<T>,
-    entity: Entity,
-    _marker: PhantomData<U>,
+    bundle: U,
 }
 
 impl<U, T> ParentEvent<U, T>
 where
     T: Clone,
+    U: Bundle + Clone,
 {
     pub fn get_action(&self) -> &Action {
         &self.action
@@ -47,72 +47,79 @@ where
     pub fn get_self_identifier(&self) -> &Identifier<T> {
         &self.self_identifier
     }
-    pub fn get_entity(&self) -> Entity {
-        self.entity.clone()
+    pub fn get_bundle(&self) -> impl Bundle {
+        self.bundle.clone()
     }
-    pub fn create(self_identifier: T, entity: Entity) -> Self {
+    pub fn create(self_identifier: T, bundle: U) -> Self {
         Self {
             action: Action::Create,
             self_identifier: Identifier(self_identifier),
-            entity,
-            _marker: PhantomData,
+            bundle,
         }
     }
-    pub fn create_or_modify(self_identifier: T, entity: Entity) -> Self {
+    pub fn create_or_modify(self_identifier: T, bundle: U) -> Self {
         Self {
             action: Action::CreateOrModify,
             self_identifier: Identifier(self_identifier),
-            entity,
-            _marker: PhantomData,
+            bundle,
         }
     }
-    pub fn update(self_identifier: T, entity: Entity) -> Self {
+    pub fn update(self_identifier: T, bundle: U) -> Self {
         Self {
             action: Action::Update,
             self_identifier: Identifier(self_identifier),
-            entity,
-            _marker: PhantomData,
+            bundle,
         }
     }
-    pub fn delete(self_identifier: T, entity: Entity) -> Self {
+    pub fn delete(self_identifier: T, bundle: U) -> Self {
         Self {
             action: Action::Delete,
             self_identifier: Identifier(self_identifier),
-            entity,
-            _marker: PhantomData,
+            bundle,
         }
     }
-    pub fn clear(self_identifier: T, entity: Entity) -> Self {
+    pub fn clear(self_identifier: T, bundle: U) -> Self {
         Self {
             action: Action::Clear,
             self_identifier: Identifier(self_identifier),
-            entity,
-            _marker: PhantomData,
+            bundle,
         }
     }
     pub fn to_history(&self, result: Result<(), ()>) -> History<T> {
         match self.action {
-            Action::Create => History::new_parent_history(Action::Create, self.self_identifier.clone(), result),
-            Action::CreateOrModify => History::new_parent_history(Action::CreateOrModify, self.self_identifier.clone(), result),
-            Action::Update => History::new_parent_history(Action::Update, self.self_identifier.clone(), result),
-            Action::Delete => History::new_parent_history(Action::Delete, self.self_identifier.clone(), result),
-            Action::Clear => History::new_parent_history(Action::Clear, self.self_identifier.clone(), result),
+            Action::Create => {
+                History::new_parent_history(Action::Create, self.self_identifier.clone(), result)
+            }
+            Action::CreateOrModify => History::new_parent_history(
+                Action::CreateOrModify,
+                self.self_identifier.clone(),
+                result,
+            ),
+            Action::Update => {
+                History::new_parent_history(Action::Update, self.self_identifier.clone(), result)
+            }
+            Action::Delete => {
+                History::new_parent_history(Action::Delete, self.self_identifier.clone(), result)
+            }
+            Action::Clear => {
+                History::new_parent_history(Action::Clear, self.self_identifier.clone(), result)
+            }
         }
     }
 }
 /// Event that is used to create, update and delete child entities
 #[derive(Event)]
-pub struct ChildEvent<U, T> {
+pub struct ChildEvent<U: Bundle, T> {
     action: Action,
     parent_identifier: Identifier<T>,
     self_identifier: Identifier<T>,
-    entity: Entity,
-    _marker: PhantomData<U>,
+    bundle: U,
 }
 
 impl<U, T> ChildEvent<U, T>
 where
     T: Clone,
+    U: Bundle + Clone,
 {
     pub fn get_action(&self) -> &Action {
         &self.action
@@ -123,61 +130,81 @@ where
     pub fn get_parent_identifier(&self) -> &Identifier<T> {
         &self.parent_identifier
     }
-    pub fn get_entity(&self) -> Entity {
-        self.entity.clone()
+    pub fn get_bundle(&self) -> U {
+        self.bundle.clone()
     }
-    pub fn create(parent_identifier: T, self_identifier: T, entity: Entity) -> Self {
+    pub fn create(parent_identifier: T, self_identifier: T, bundle: U) -> Self {
         Self {
             action: Action::Create,
             self_identifier: Identifier(self_identifier),
             parent_identifier: Identifier(parent_identifier),
-            entity,
-            _marker: PhantomData,
+            bundle,
         }
     }
-    pub fn create_or_modify(parent_identifier: T, self_identifier: T, entity: Entity) -> Self {
+    pub fn create_or_modify(parent_identifier: T, self_identifier: T, bundle: U) -> Self {
         Self {
             action: Action::CreateOrModify,
             self_identifier: Identifier(self_identifier),
             parent_identifier: Identifier(parent_identifier),
-            entity,
-            _marker: PhantomData,
+            bundle,
         }
     }
-    pub fn update(parent_identifier: T, self_identifier: T, entity: Entity) -> Self {
+    pub fn update(parent_identifier: T, self_identifier: T, bundle: U) -> Self {
         Self {
             action: Action::Update,
             self_identifier: Identifier(self_identifier),
             parent_identifier: Identifier(parent_identifier),
-            entity,
-            _marker: PhantomData,
+            bundle,
         }
     }
-    pub fn delete(parent_identifier: T, self_identifier: T, entity: Entity) -> Self {
+    pub fn delete(parent_identifier: T, self_identifier: T, bundle: U) -> Self {
         Self {
             action: Action::Delete,
             self_identifier: Identifier(self_identifier),
             parent_identifier: Identifier(parent_identifier),
-            entity,
-            _marker: PhantomData,
+            bundle,
         }
     }
-    pub fn clear(parent_identifier: T, self_identifier: T, entity: Entity) -> Self {
+    pub fn clear(parent_identifier: T, self_identifier: T, bundle: U) -> Self {
         Self {
             action: Action::Clear,
             self_identifier: Identifier(self_identifier),
             parent_identifier: Identifier(parent_identifier),
-            entity,
-            _marker: PhantomData,
+            bundle,
         }
     }
     pub fn to_history(&self, result: Result<(), ()>) -> History<T> {
         match self.action {
-            Action::Create => History::new_child_history(Action::Create, self.parent_identifier.clone(), self.self_identifier.clone(), result),
-            Action::CreateOrModify => History::new_child_history(Action::CreateOrModify, self.parent_identifier.clone(), self.self_identifier.clone(), result),
-            Action::Update => History::new_child_history(Action::Update, self.parent_identifier.clone(), self.self_identifier.clone(), result),
-            Action::Delete => History::new_child_history(Action::Delete, self.parent_identifier.clone(), self.self_identifier.clone(), result),
-            Action::Clear => History::new_child_history(Action::Clear, self.parent_identifier.clone(), self.self_identifier.clone(), result),
+            Action::Create => History::new_child_history(
+                Action::Create,
+                self.parent_identifier.clone(),
+                self.self_identifier.clone(),
+                result,
+            ),
+            Action::CreateOrModify => History::new_child_history(
+                Action::CreateOrModify,
+                self.parent_identifier.clone(),
+                self.self_identifier.clone(),
+                result,
+            ),
+            Action::Update => History::new_child_history(
+                Action::Update,
+                self.parent_identifier.clone(),
+                self.self_identifier.clone(),
+                result,
+            ),
+            Action::Delete => History::new_child_history(
+                Action::Delete,
+                self.parent_identifier.clone(),
+                self.self_identifier.clone(),
+                result,
+            ),
+            Action::Clear => History::new_child_history(
+                Action::Clear,
+                self.parent_identifier.clone(),
+                self.self_identifier.clone(),
+                result,
+            ),
         }
     }
 }
@@ -212,7 +239,10 @@ where
     }
 
     /// Get the history by the parent identifier.
-    pub fn get_histories_by_parent_identifier(&self, parent_identifier: &Identifier<T>) -> Vec<&History<T>> {
+    pub fn get_histories_by_parent_identifier(
+        &self,
+        parent_identifier: &Identifier<T>,
+    ) -> Vec<&History<T>> {
         let mut histories = Vec::new();
         for history in &self.histories {
             if &history.parent_identifier == parent_identifier {
@@ -223,7 +253,10 @@ where
     }
 
     /// Get the history by the child identifier.
-    pub fn get_histories_by_child_identifier(&self, child_identifier: &Identifier<T>) -> Vec<&History<T>> {
+    pub fn get_histories_by_child_identifier(
+        &self,
+        child_identifier: &Identifier<T>,
+    ) -> Vec<&History<T>> {
         let mut histories = Vec::new();
         for history in &self.histories {
             if let Some(identifier) = &history.child_identifier {
@@ -236,7 +269,10 @@ where
     }
 
     /// Get the result by the parent identifier.
-    pub fn get_result_from_parent_identifier(&self, parent_identifier: &Identifier<T>) -> Result<(), ()> {
+    pub fn get_result_from_parent_identifier(
+        &self,
+        parent_identifier: &Identifier<T>,
+    ) -> Result<(), ()> {
         for history in &self.histories {
             if &history.parent_identifier == parent_identifier {
                 return history.result;
@@ -246,7 +282,10 @@ where
     }
 
     /// Get the result by the child identifier.
-    pub fn get_result_from_child_identifier(&self, child_identifier: &Identifier<T>) -> Result<(), ()> {
+    pub fn get_result_from_child_identifier(
+        &self,
+        child_identifier: &Identifier<T>,
+    ) -> Result<(), ()> {
         for history in &self.histories {
             if let Some(identifier) = &history.child_identifier {
                 if identifier == child_identifier {
@@ -264,12 +303,14 @@ where
 
     /// Clear the parent histories.
     pub fn clear_parent_history(&mut self, parent_identifier: &Identifier<T>) {
-        self.histories.retain(|h| &h.parent_identifier != parent_identifier);
+        self.histories
+            .retain(|h| &h.parent_identifier != parent_identifier);
     }
 
     /// Clear the child histories.
     pub fn clear_child_history(&mut self, child_identifier: &Identifier<T>) {
-        self.histories.retain(|h| h.child_identifier != Some(child_identifier.clone()));
+        self.histories
+            .retain(|h| h.child_identifier != Some(child_identifier.clone()));
     }
 
     /// Pop the history.
@@ -280,7 +321,11 @@ where
 
 impl<T> History<T> {
     /// Create a new parent history.
-    pub fn new_parent_history(action: Action, parent_identifier: Identifier<T>, result: Result<(), ()>) -> Self {
+    pub fn new_parent_history(
+        action: Action,
+        parent_identifier: Identifier<T>,
+        result: Result<(), ()>,
+    ) -> Self {
         Self {
             action,
             parent_identifier,
@@ -290,7 +335,12 @@ impl<T> History<T> {
     }
 
     /// Create a new child history.
-    pub fn new_child_history(action: Action, parent_identifier: Identifier<T>, child_identifier: Identifier<T>, result: Result<(), ()>) -> Self {
+    pub fn new_child_history(
+        action: Action,
+        parent_identifier: Identifier<T>,
+        child_identifier: Identifier<T>,
+        result: Result<(), ()>,
+    ) -> Self {
         Self {
             action,
             parent_identifier,


### PR DESCRIPTION
Using entities for the events and systems will have a bug where the entities will spawn for a frame before getting despawned.

This behavior is not desirable as systems with `Changed` queries might get triggered prematurely in cases where entities should be spawned.

Using bundles is more elegant as the bundles themselves are passed via the events and only spawn when the parent and/or child identifier exist.